### PR TITLE
Include standard-library headers where they are used

### DIFF
--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -19,6 +19,8 @@
 
 #include "Action.hpp"
 
+#include <functional>
+
 #include "ControlSequencer.hpp"
 #include "Files.hpp"
 #include "Engine.hpp"

--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -20,6 +20,7 @@
 #include "Action.hpp"
 
 #include <functional>
+#include <memory>
 
 #include "ControlSequencer.hpp"
 #include "Files.hpp"

--- a/src/Action.hpp
+++ b/src/Action.hpp
@@ -20,8 +20,8 @@
 #ifndef ACTION_H
 #define	ACTION_H
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "Chord.hpp"
 

--- a/src/ActionEditor.cpp
+++ b/src/ActionEditor.cpp
@@ -19,6 +19,8 @@
 
 #include "ActionEditor.hpp"
 
+#include <functional>
+
 #include "Action.hpp"
 #include "Files.hpp"
 #include "NoteSequencer.hpp"

--- a/src/ActionEditor.cpp
+++ b/src/ActionEditor.cpp
@@ -20,6 +20,7 @@
 #include "ActionEditor.hpp"
 
 #include <functional>
+#include <memory>
 
 #include "Action.hpp"
 #include "Files.hpp"

--- a/src/ActionEditor.hpp
+++ b/src/ActionEditor.hpp
@@ -21,6 +21,7 @@
 #define	ACTIONEDITOR_H
 
 #include <memory>
+
 #include <gtkmm.h>
 
 #include "Chord.hpp"

--- a/src/AtomContainer.cpp
+++ b/src/AtomContainer.cpp
@@ -20,6 +20,7 @@
 #include "AtomContainer.hpp"
 
 #include <algorithm>
+#include <vector>
 
 AtomContainer::AtomContainer(){
 }

--- a/src/AtomContainer.cpp
+++ b/src/AtomContainer.cpp
@@ -20,6 +20,7 @@
 #include "AtomContainer.hpp"
 
 #include <algorithm>
+#include <set>
 #include <vector>
 
 AtomContainer::AtomContainer(){

--- a/src/Chord.cpp
+++ b/src/Chord.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "shared.hpp"
 

--- a/src/Chord.cpp
+++ b/src/Chord.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <map>
+#include <string>
 
 #include "shared.hpp"
 

--- a/src/Chord.cpp
+++ b/src/Chord.cpp
@@ -21,6 +21,7 @@
 #include "Chord.hpp"
 
 #include <iostream>
+#include <map>
 
 #include "shared.hpp"
 

--- a/src/Chord.hpp
+++ b/src/Chord.hpp
@@ -22,6 +22,7 @@
 #define	CHORD_H
 
 #include <map>
+#include <string>
 #include <vector>
 
 #include <boost/signals2.hpp>

--- a/src/ChordWidget.cpp
+++ b/src/ChordWidget.cpp
@@ -19,6 +19,8 @@
 
 #include "ChordWidget.hpp"
 
+#include <vector>
+
 #include "Chord.hpp"
 #include "Sequencer.hpp"
 #include "TreeModels.hpp"

--- a/src/ChordWidget.cpp
+++ b/src/ChordWidget.cpp
@@ -19,6 +19,7 @@
 
 #include "ChordWidget.hpp"
 
+#include <functional>
 #include <vector>
 
 #include "Chord.hpp"

--- a/src/ChordWidget.cpp
+++ b/src/ChordWidget.cpp
@@ -20,6 +20,7 @@
 #include "ChordWidget.hpp"
 
 #include <functional>
+#include <memory>
 #include <vector>
 
 #include "Chord.hpp"

--- a/src/ChordWidget.hpp
+++ b/src/ChordWidget.hpp
@@ -20,6 +20,8 @@
 #ifndef CHORDWIDGET_H
 #define	CHORDWIDGET_H
 
+#include <vector>
+
 #include <gtkmm.h>
 
 #include <boost/signals2.hpp>

--- a/src/DiodeMidiEvent.cpp
+++ b/src/DiodeMidiEvent.cpp
@@ -19,6 +19,8 @@
 
 #include "DiodeMidiEvent.hpp"
 
+#include <memory>
+
 
 DiodeMidiEvent::DiodeMidiEvent(std::weak_ptr<Sequencer> target_, DiodeType type_, double time_, int value_, int color_, int max_res_){
     target = target_;

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -21,6 +21,7 @@
 
 #include <iostream>
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "AtomContainer.hpp"

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -19,6 +19,7 @@
 
 #include "Engine.hpp"
 
+#include <algorithm>
 #include <iostream>
 #include <map>
 #include <memory>

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -21,6 +21,7 @@
 
 #include <iostream>
 #include <map>
+#include <vector>
 
 #include "AtomContainer.hpp"
 #include "Configuration.hpp"

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -20,6 +20,7 @@
 #include "Engine.hpp"
 
 #include <iostream>
+#include <map>
 
 #include "AtomContainer.hpp"
 #include "Configuration.hpp"

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -21,6 +21,7 @@
 
 #include <iostream>
 #include <map>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/src/Engine.hpp
+++ b/src/Engine.hpp
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <deque>
+#include <map>
 
 #include <boost/signals2.hpp>
 namespace bs2 = boost::signals2;

--- a/src/Engine.hpp
+++ b/src/Engine.hpp
@@ -22,6 +22,7 @@
 #ifndef MIDIDRIVER_H
 #define	MIDIDRIVER_H
 
+#include <atomic>
 #include <deque>
 
 #include <boost/signals2.hpp>

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -21,6 +21,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include <gtkmm.h>
 

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -20,6 +20,7 @@
 #include "Event.hpp"
 
 #include <iostream>
+#include <string>
 
 #include <gtkmm.h>
 

--- a/src/Event.hpp
+++ b/src/Event.hpp
@@ -20,8 +20,8 @@
 #ifndef EVENT_H
 #define	EVENT_H
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <boost/signals2.hpp>
 namespace bs2 = boost::signals2;

--- a/src/EventEditor.cpp
+++ b/src/EventEditor.cpp
@@ -19,6 +19,8 @@
 
 #include "EventEditor.hpp"
 
+#include <functional>
+
 #include "Configuration.hpp"
 #include "Event.hpp"
 #include "Files.hpp"

--- a/src/EventsWidget.cpp
+++ b/src/EventsWidget.cpp
@@ -19,6 +19,7 @@
 
 #include "EventsWidget.hpp"
 
+#include <functional>
 #include <vector>
 
 #include "Action.hpp"

--- a/src/EventsWidget.cpp
+++ b/src/EventsWidget.cpp
@@ -19,6 +19,8 @@
 
 #include "EventsWidget.hpp"
 
+#include <vector>
+
 #include "Action.hpp"
 #include "Event.hpp"
 #include "Files.hpp"

--- a/src/EventsWidget.hpp
+++ b/src/EventsWidget.hpp
@@ -21,6 +21,8 @@
 #ifndef EVENTSWIDGET_H
 #define	EVENTSWIDGET_H
 
+#include <vector>
+
 #include <gtkmm.h>
 
 #include <boost/signals2.hpp>

--- a/src/Files.cpp
+++ b/src/Files.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 
 #include <gtkmm.h>
 

--- a/src/Files.cpp
+++ b/src/Files.cpp
@@ -21,6 +21,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <map>
 
 #include <gtkmm.h>
 

--- a/src/Files.cpp
+++ b/src/Files.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <string>
 
 #include <gtkmm.h>
 

--- a/src/Files.cpp
+++ b/src/Files.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,7 @@
 
 #include "MainWindow.hpp"
 
+#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <memory>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -20,6 +20,7 @@
 #include "MainWindow.hpp"
 
 #include <iostream>
+#include <vector>
 
 #include "Configuration.hpp"
 #include "ControlSequencer.hpp"

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -21,6 +21,7 @@
 
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <vector>
 
 #include "Configuration.hpp"

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,7 @@
 
 #include "MainWindow.hpp"
 
+#include <functional>
 #include <iostream>
 #include <vector>
 

--- a/src/NoteWidget.cpp
+++ b/src/NoteWidget.cpp
@@ -20,6 +20,7 @@
 #include "NoteWidget.hpp"
 
 #include <algorithm>
+#include <string>
 
 #include "Chord.hpp"
 

--- a/src/NoteWidget.cpp
+++ b/src/NoteWidget.cpp
@@ -20,6 +20,7 @@
 #include "NoteWidget.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <string>
 
 #include "Chord.hpp"

--- a/src/PatternWidget.cpp
+++ b/src/PatternWidget.cpp
@@ -19,6 +19,7 @@
 
 #include "PatternWidget.hpp"
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <set>

--- a/src/PatternWidget.cpp
+++ b/src/PatternWidget.cpp
@@ -19,6 +19,8 @@
 
 #include "PatternWidget.hpp"
 
+#include <vector>
+
 /* TODO: Replace gettimeofday with more portable GetRealTime which uses Glib. */
 #include <sys/time.h>
 

--- a/src/PatternWidget.cpp
+++ b/src/PatternWidget.cpp
@@ -19,6 +19,7 @@
 
 #include "PatternWidget.hpp"
 
+#include <set>
 #include <vector>
 
 /* TODO: Replace gettimeofday with more portable GetRealTime which uses Glib. */

--- a/src/PatternWidget.cpp
+++ b/src/PatternWidget.cpp
@@ -19,6 +19,7 @@
 
 #include "PatternWidget.hpp"
 
+#include <functional>
 #include <set>
 #include <vector>
 

--- a/src/PatternWidget.cpp
+++ b/src/PatternWidget.cpp
@@ -20,6 +20,7 @@
 #include "PatternWidget.hpp"
 
 #include <functional>
+#include <memory>
 #include <set>
 #include <vector>
 

--- a/src/PatternWidget.hpp
+++ b/src/PatternWidget.hpp
@@ -21,6 +21,7 @@
 #define	PATTERNWIDGET_H
 
 #include <memory>
+#include <set>
 
 #include <gtkmm.h>
 

--- a/src/Sequencer.cpp
+++ b/src/Sequencer.cpp
@@ -19,6 +19,7 @@
 
 #include "Sequencer.hpp"
 
+#include <algorithm>
 #include <memory>
 
 #include "AtomContainer.hpp"

--- a/src/Sequencer.cpp
+++ b/src/Sequencer.cpp
@@ -19,6 +19,8 @@
 
 #include "Sequencer.hpp"
 
+#include <memory>
+
 #include "AtomContainer.hpp"
 
 

--- a/src/Sequencer.hpp
+++ b/src/Sequencer.hpp
@@ -21,6 +21,8 @@
 #ifndef SEQUENCER_H
 #define	SEQUENCER_H
 
+#include <vector>
+
 #include <boost/signals2.hpp>
 namespace bs2 = boost::signals2;
 

--- a/src/SequencerManager.cpp
+++ b/src/SequencerManager.cpp
@@ -21,6 +21,7 @@
 #include "SequencerManager.hpp"
 
 #include <algorithm>
+#include <mutex>
 #include <vector>
 
 

--- a/src/SequencerManager.cpp
+++ b/src/SequencerManager.cpp
@@ -21,6 +21,7 @@
 #include "SequencerManager.hpp"
 
 #include <algorithm>
+#include <vector>
 
 
 std::vector<std::shared_ptr<Sequencer>> SequencerManager::sequencers;

--- a/src/SequencerManager.hpp
+++ b/src/SequencerManager.hpp
@@ -21,8 +21,8 @@
 */
 
 
-#include <vector>
 #include <mutex>
+#include <vector>
 
 #include <boost/signals2.hpp>
 namespace bs2 = boost::signals2;

--- a/src/SequencerWidget.cpp
+++ b/src/SequencerWidget.cpp
@@ -19,6 +19,8 @@
 
 #include "SequencerWidget.hpp"
 
+#include <functional>
+
 #include "AtomContainer.hpp"
 #include "ControlSequencer.hpp"
 #include "Files.hpp"

--- a/src/SequencerWidget.cpp
+++ b/src/SequencerWidget.cpp
@@ -20,6 +20,7 @@
 #include "SequencerWidget.hpp"
 
 #include <functional>
+#include <memory>
 
 #include "AtomContainer.hpp"
 #include "ControlSequencer.hpp"

--- a/src/SequencerWidget.hpp
+++ b/src/SequencerWidget.hpp
@@ -19,6 +19,8 @@
 #ifndef SEQUENCERWIDGET_H
 #define	SEQUENCERWIDGET_H
 
+#include <vector>
+
 #include <boost/signals2.hpp>
 namespace bs2 = boost::signals2;
 

--- a/src/SettingsWindow.cpp
+++ b/src/SettingsWindow.cpp
@@ -19,6 +19,8 @@
 
 #include "SettingsWindow.hpp"
 
+#include <functional>
+
 #include "Configuration.hpp"
 #include "shared.hpp"
 

--- a/src/TreeModels.cpp
+++ b/src/TreeModels.cpp
@@ -17,6 +17,8 @@
     along with HarmonySEQ.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <map>
+
 #include "TreeModels.hpp"
 
 #include "Action.hpp"

--- a/src/TreeModels.cpp
+++ b/src/TreeModels.cpp
@@ -17,10 +17,10 @@
     along with HarmonySEQ.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "TreeModels.hpp"
+
 #include <map>
 #include <string>
-
-#include "TreeModels.hpp"
 
 #include "Action.hpp"
 #include "Event.hpp"

--- a/src/TreeModels.cpp
+++ b/src/TreeModels.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <map>
+#include <string>
 
 #include "TreeModels.hpp"
 

--- a/src/TreeModels.hpp
+++ b/src/TreeModels.hpp
@@ -20,6 +20,8 @@
 #ifndef TREEMODELS_H
 #define	TREEMODELS_H
 
+#include <vector>
+
 #include <boost/signals2.hpp>
 namespace bs2 = boost::signals2;
 

--- a/src/UIMain.cpp
+++ b/src/UIMain.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <deque>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/src/UIMain.cpp
+++ b/src/UIMain.cpp
@@ -19,6 +19,7 @@
 
 #include <deque>
 #include <mutex>
+#include <string>
 #include <thread>
 
 #include <gtkmm.h>

--- a/src/UIMain.cpp
+++ b/src/UIMain.cpp
@@ -17,6 +17,7 @@
     along with HarmonySEQ.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <chrono>
 #include <deque>
 #include <functional>
 #include <mutex>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <getopt.h>
 #include <iostream>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
     along with HarmonySEQ.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <map>
 #include <string>
 #include <thread>
 

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -17,6 +17,8 @@
     along with HarmonySEQ.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <string>
+
 #include "resources.hpp"
 
 Glib::RefPtr< Gdk::Pixbuf > harmonySEQ_logo_48;

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -17,9 +17,9 @@
     along with HarmonySEQ.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <string>
-
 #include "resources.hpp"
+
+#include <string>
 
 Glib::RefPtr< Gdk::Pixbuf > harmonySEQ_logo_48;
 Glib::RefPtr< Gdk::Pixbuf > metronome_icon_24;

--- a/src/resources.hpp
+++ b/src/resources.hpp
@@ -20,6 +20,8 @@
 #ifndef RESOURCES_HPP
 #define RESOURCES_HPP
 
+#include <string>
+
 #include <glibmm/ustring.h>
 #include <gdkmm/pixbuf.h>
 

--- a/src/shared.hpp
+++ b/src/shared.hpp
@@ -1,6 +1,7 @@
 #ifndef SHARED_HPP
 #define SHARED_HPP
 
+#include <functional>
 #include <map>
 #include <string>
 #include <functional>


### PR DESCRIPTION
This would fix https://github.com/rafalcieslak/harmonySEQ/issues/7 – not only fixing the compile on Fedora, but hopefully preventing similar issues on other platforms.